### PR TITLE
feat: UIの統一とページ遷移のUI追加

### DIFF
--- a/packages/client/app/components/header.tsx
+++ b/packages/client/app/components/header.tsx
@@ -1,0 +1,110 @@
+import { Link, useNavigate } from "react-router";
+import { css } from "styled-system/css";
+
+export default function Header() {
+	const navigate = useNavigate();
+
+	const handleLogout = () => {
+		localStorage.removeItem("token");
+		navigate("/login");
+	};
+
+	return (
+		<header
+			className={css({
+				display: "flex",
+				justifyContent: "space-between",
+				alignItems: "center",
+				padding: "12px 24px",
+				backgroundColor: "#fff",
+				borderBottom: "1px solid #e5e5e5",
+			})}
+		>
+			<Link
+				to="/timeline"
+				className={css({
+					fontSize: "20px",
+					fontWeight: "bold",
+					color: "#1a1a1a",
+					textDecoration: "none",
+					_hover: {
+						color: "#4a4a4a",
+					},
+				})}
+			>
+				maxi-Q
+			</Link>
+
+			<nav
+				className={css({
+					display: "flex",
+					alignItems: "center",
+					gap: "24px",
+				})}
+			>
+				<Link
+					to="/timeline"
+					className={css({
+						color: "#4a4a4a",
+						textDecoration: "none",
+						fontSize: "14px",
+						_hover: {
+							color: "#1a1a1a",
+						},
+					})}
+				>
+					タイムライン
+				</Link>
+
+				<Link
+					to="/post/question"
+					className={css({
+						color: "#4a4a4a",
+						textDecoration: "none",
+						fontSize: "14px",
+						_hover: {
+							color: "#1a1a1a",
+						},
+					})}
+				>
+					質問投稿
+				</Link>
+
+				<Link
+					to="/users/profile"
+					className={css({
+						color: "#4a4a4a",
+						textDecoration: "none",
+						fontSize: "14px",
+						_hover: {
+							color: "#1a1a1a",
+						},
+					})}
+				>
+					マイページ
+				</Link>
+
+				<button
+					type="button"
+					onClick={handleLogout}
+					className={css({
+						padding: "6px 12px",
+						fontSize: "14px",
+						color: "#4a4a4a",
+						backgroundColor: "transparent",
+						border: "1px solid #d4d4d4",
+						borderRadius: "4px",
+						cursor: "pointer",
+						transition: "all 0.2s",
+						_hover: {
+							backgroundColor: "#f5f5f5",
+							borderColor: "#a3a3a3",
+						},
+					})}
+				>
+					ログアウト
+				</button>
+			</nav>
+		</header>
+	);
+}

--- a/packages/client/app/components/header.tsx
+++ b/packages/client/app/components/header.tsx
@@ -1,5 +1,15 @@
 import { Link, useNavigate } from "react-router";
 import { css } from "styled-system/css";
+import { Button } from "~/components/ui/button";
+
+const navLinkStyles = css({
+	color: "#4a4a4a",
+	textDecoration: "none",
+	fontSize: "14px",
+	_hover: {
+		color: "#1a1a1a",
+	},
+});
 
 export default function Header() {
 	const navigate = useNavigate();
@@ -42,68 +52,21 @@ export default function Header() {
 					gap: "24px",
 				})}
 			>
-				<Link
-					to="/timeline"
-					className={css({
-						color: "#4a4a4a",
-						textDecoration: "none",
-						fontSize: "14px",
-						_hover: {
-							color: "#1a1a1a",
-						},
-					})}
-				>
+				<Link to="/timeline" className={navLinkStyles}>
 					タイムライン
 				</Link>
 
-				<Link
-					to="/post/question"
-					className={css({
-						color: "#4a4a4a",
-						textDecoration: "none",
-						fontSize: "14px",
-						_hover: {
-							color: "#1a1a1a",
-						},
-					})}
-				>
+				<Link to="/post/question" className={navLinkStyles}>
 					質問投稿
 				</Link>
 
-				<Link
-					to="/users/profile"
-					className={css({
-						color: "#4a4a4a",
-						textDecoration: "none",
-						fontSize: "14px",
-						_hover: {
-							color: "#1a1a1a",
-						},
-					})}
-				>
+				<Link to="/users/profile" className={navLinkStyles}>
 					マイページ
 				</Link>
 
-				<button
-					type="button"
-					onClick={handleLogout}
-					className={css({
-						padding: "6px 12px",
-						fontSize: "14px",
-						color: "#4a4a4a",
-						backgroundColor: "transparent",
-						border: "1px solid #d4d4d4",
-						borderRadius: "4px",
-						cursor: "pointer",
-						transition: "all 0.2s",
-						_hover: {
-							backgroundColor: "#f5f5f5",
-							borderColor: "#a3a3a3",
-						},
-					})}
-				>
+				<Button variant="secondary" size="sm" onClick={handleLogout}>
 					ログアウト
-				</button>
+				</Button>
 			</nav>
 		</header>
 	);

--- a/packages/client/app/components/ui/button.tsx
+++ b/packages/client/app/components/ui/button.tsx
@@ -92,5 +92,7 @@ export function Button({
 	}
 
 	const { as: _, ...buttonProps } = props;
-	return <button type="button" className={combinedClassName} {...buttonProps} />;
+	return (
+		<button type="button" className={combinedClassName} {...buttonProps} />
+	);
 }

--- a/packages/client/app/components/ui/button.tsx
+++ b/packages/client/app/components/ui/button.tsx
@@ -1,0 +1,96 @@
+import { Link } from "react-router";
+import { css, cx } from "styled-system/css";
+
+const baseStyles = css({
+	display: "inline-flex",
+	alignItems: "center",
+	justifyContent: "center",
+	padding: "10px 20px",
+	fontSize: "14px",
+	fontWeight: "bold",
+	borderRadius: "6px",
+	cursor: "pointer",
+	transition: "all 0.2s",
+	textDecoration: "none",
+	border: "none",
+	_disabled: {
+		opacity: 0.6,
+		cursor: "not-allowed",
+	},
+});
+
+const variants = {
+	primary: css({
+		backgroundColor: "#1a1a1a",
+		color: "#fff",
+		_hover: {
+			backgroundColor: "#333",
+		},
+	}),
+	secondary: css({
+		backgroundColor: "#fff",
+		color: "#1a1a1a",
+		border: "1px solid #d4d4d4",
+		_hover: {
+			backgroundColor: "#f5f5f5",
+			borderColor: "#a3a3a3",
+		},
+	}),
+	ghost: css({
+		backgroundColor: "transparent",
+		color: "#4a4a4a",
+		_hover: {
+			backgroundColor: "#f5f5f5",
+		},
+	}),
+};
+
+const sizes = {
+	sm: css({
+		padding: "6px 12px",
+		fontSize: "13px",
+	}),
+	md: css({
+		padding: "10px 20px",
+		fontSize: "14px",
+	}),
+	lg: css({
+		padding: "12px 32px",
+		fontSize: "16px",
+	}),
+};
+
+type ButtonProps = {
+	variant?: keyof typeof variants;
+	size?: keyof typeof sizes;
+	disabled?: boolean;
+	className?: string;
+} & (
+	| ({ as?: "button" } & React.ButtonHTMLAttributes<HTMLButtonElement>)
+	| ({ as: "link"; to: string } & Omit<
+			React.AnchorHTMLAttributes<HTMLAnchorElement>,
+			"href"
+	  >)
+);
+
+export function Button({
+	variant = "primary",
+	size = "md",
+	className,
+	...props
+}: ButtonProps) {
+	const combinedClassName = cx(
+		baseStyles,
+		variants[variant],
+		sizes[size],
+		className,
+	);
+
+	if (props.as === "link") {
+		const { as: _, to, ...linkProps } = props;
+		return <Link to={to} className={combinedClassName} {...linkProps} />;
+	}
+
+	const { as: _, ...buttonProps } = props;
+	return <button type="button" className={combinedClassName} {...buttonProps} />;
+}

--- a/packages/client/app/components/ui/input.tsx
+++ b/packages/client/app/components/ui/input.tsx
@@ -1,0 +1,52 @@
+import { css, cx } from "styled-system/css";
+
+const inputStyles = css({
+	width: "100%",
+	padding: "10px 12px",
+	fontSize: "14px",
+	borderRadius: "6px",
+	border: "1px solid #d4d4d4",
+	backgroundColor: "#fff",
+	color: "#1a1a1a",
+	outline: "none",
+	transition: "all 0.2s",
+	_focus: {
+		borderColor: "#1a1a1a",
+		boxShadow: "0 0 0 1px #1a1a1a",
+	},
+	_disabled: {
+		backgroundColor: "#f5f5f5",
+		cursor: "not-allowed",
+	},
+	_placeholder: {
+		color: "#a3a3a3",
+	},
+});
+
+const labelStyles = css({
+	display: "block",
+	fontSize: "14px",
+	fontWeight: "medium",
+	color: "#4a4a4a",
+	marginBottom: "6px",
+});
+
+type InputProps = {
+	label?: string;
+	className?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+export function Input({ label, className, id, ...props }: InputProps) {
+	const inputId = id || props.name;
+
+	return (
+		<div>
+			{label && (
+				<label htmlFor={inputId} className={labelStyles}>
+					{label}
+				</label>
+			)}
+			<input id={inputId} className={cx(inputStyles, className)} {...props} />
+		</div>
+	);
+}

--- a/packages/client/app/components/ui/loading.tsx
+++ b/packages/client/app/components/ui/loading.tsx
@@ -1,0 +1,22 @@
+import { css } from "styled-system/css";
+
+type LoadingProps = {
+	message?: string;
+};
+
+export function Loading({ message = "読み込み中..." }: LoadingProps) {
+	return (
+		<div
+			className={css({
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: "24px",
+				color: "#6b6b6b",
+				fontSize: "14px",
+			})}
+		>
+			{message}
+		</div>
+	);
+}

--- a/packages/client/app/components/ui/textarea.tsx
+++ b/packages/client/app/components/ui/textarea.tsx
@@ -1,0 +1,58 @@
+import { css, cx } from "styled-system/css";
+
+const textareaStyles = css({
+	width: "100%",
+	padding: "10px 12px",
+	fontSize: "14px",
+	borderRadius: "6px",
+	border: "1px solid #d4d4d4",
+	backgroundColor: "#fff",
+	color: "#1a1a1a",
+	outline: "none",
+	transition: "all 0.2s",
+	resize: "vertical",
+	minHeight: "120px",
+	_focus: {
+		borderColor: "#1a1a1a",
+		boxShadow: "0 0 0 1px #1a1a1a",
+	},
+	_disabled: {
+		backgroundColor: "#f5f5f5",
+		cursor: "not-allowed",
+	},
+	_placeholder: {
+		color: "#a3a3a3",
+	},
+});
+
+const labelStyles = css({
+	display: "block",
+	fontSize: "14px",
+	fontWeight: "medium",
+	color: "#4a4a4a",
+	marginBottom: "6px",
+});
+
+type TextareaProps = {
+	label?: string;
+	className?: string;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function Textarea({ label, className, id, ...props }: TextareaProps) {
+	const textareaId = id || props.name;
+
+	return (
+		<div>
+			{label && (
+				<label htmlFor={textareaId} className={labelStyles}>
+					{label}
+				</label>
+			)}
+			<textarea
+				id={textareaId}
+				className={cx(textareaStyles, className)}
+				{...props}
+			/>
+		</div>
+	);
+}

--- a/packages/client/app/routes/home.tsx
+++ b/packages/client/app/routes/home.tsx
@@ -1,37 +1,85 @@
-import { useState } from "react";
+import { Link } from "react-router";
 import { css } from "styled-system/css";
-import type { User } from "~/types/user";
-
-// export function meta({}: Route.MetaArgs) {
-//   return [
-//     { title: "New React Router App" },
-//     { name: "description", content: "Welcome to React Router!" },
-//   ];
-// }
 
 export default function Home() {
-	const [users, _setUsers] = useState<User[]>([]);
-
 	return (
-		<div>
-			<p
+		<div
+			className={css({
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				minHeight: "100vh",
+				backgroundColor: "#fafafa",
+			})}
+		>
+			<h1
 				className={css({
-					fontSize: "20px",
+					fontSize: "48px",
 					fontWeight: "bold",
-					color: "blue.500",
+					color: "#1a1a1a",
+					marginBottom: "16px",
 				})}
 			>
-				Welcome to the Home Page!
+				maxi-Q
+			</h1>
+
+			<p
+				className={css({
+					fontSize: "18px",
+					color: "#6b6b6b",
+					marginBottom: "48px",
+				})}
+			>
+				匿名で質問・回答ができるQ&Aプラットフォーム
 			</p>
 
-			<h2>User List</h2>
-			<ul>
-				{users.map((user) => (
-					<li key={user.id}>
-						{user.displayId} - {user.name} - {user.email}
-					</li>
-				))}
-			</ul>
+			<div
+				className={css({
+					display: "flex",
+					gap: "16px",
+				})}
+			>
+				<Link
+					to="/login"
+					className={css({
+						padding: "12px 32px",
+						fontSize: "16px",
+						fontWeight: "bold",
+						color: "#fff",
+						backgroundColor: "#1a1a1a",
+						borderRadius: "6px",
+						textDecoration: "none",
+						transition: "background-color 0.2s",
+						_hover: {
+							backgroundColor: "#333",
+						},
+					})}
+				>
+					ログイン
+				</Link>
+
+				<Link
+					to="/register"
+					className={css({
+						padding: "12px 32px",
+						fontSize: "16px",
+						fontWeight: "bold",
+						color: "#1a1a1a",
+						backgroundColor: "#fff",
+						border: "1px solid #d4d4d4",
+						borderRadius: "6px",
+						textDecoration: "none",
+						transition: "all 0.2s",
+						_hover: {
+							backgroundColor: "#f5f5f5",
+							borderColor: "#a3a3a3",
+						},
+					})}
+				>
+					新規登録
+				</Link>
+			</div>
 		</div>
 	);
 }

--- a/packages/client/app/routes/home.tsx
+++ b/packages/client/app/routes/home.tsx
@@ -1,5 +1,5 @@
-import { Link } from "react-router";
 import { css } from "styled-system/css";
+import { Button } from "~/components/ui/button";
 
 export default function Home() {
 	return (
@@ -40,45 +40,13 @@ export default function Home() {
 					gap: "16px",
 				})}
 			>
-				<Link
-					to="/login"
-					className={css({
-						padding: "12px 32px",
-						fontSize: "16px",
-						fontWeight: "bold",
-						color: "#fff",
-						backgroundColor: "#1a1a1a",
-						borderRadius: "6px",
-						textDecoration: "none",
-						transition: "background-color 0.2s",
-						_hover: {
-							backgroundColor: "#333",
-						},
-					})}
-				>
+				<Button as="link" to="/login" size="lg">
 					ログイン
-				</Link>
+				</Button>
 
-				<Link
-					to="/register"
-					className={css({
-						padding: "12px 32px",
-						fontSize: "16px",
-						fontWeight: "bold",
-						color: "#1a1a1a",
-						backgroundColor: "#fff",
-						border: "1px solid #d4d4d4",
-						borderRadius: "6px",
-						textDecoration: "none",
-						transition: "all 0.2s",
-						_hover: {
-							backgroundColor: "#f5f5f5",
-							borderColor: "#a3a3a3",
-						},
-					})}
-				>
+				<Button as="link" to="/register" variant="secondary" size="lg">
 					新規登録
-				</Link>
+				</Button>
 			</div>
 		</div>
 	);

--- a/packages/client/app/routes/layout.tsx
+++ b/packages/client/app/routes/layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router";
 import Header from "~/components/header";
+import { Loading } from "~/components/ui/loading";
 import { useAuth } from "~/hooks/use-auth";
 
 // TODO ログインしていなくてリダイレクトされたときにUIエラーを出す。
@@ -19,7 +20,7 @@ export default function ProtectedLayout() {
 		return (
 			<>
 				<Header />
-				<div style={{ padding: "20px" }}>Loading...</div>
+				<Loading />
 			</>
 		);
 	}
@@ -28,10 +29,7 @@ export default function ProtectedLayout() {
 		return (
 			<>
 				<Header />
-				<div style={{ padding: "20px", color: "red" }}>
-					<h2>エラーが発生しました</h2>
-					<p>{error.message}</p>
-				</div>
+				<Loading message={`エラー: ${error.message}`} />
 			</>
 		);
 	}

--- a/packages/client/app/routes/layout.tsx
+++ b/packages/client/app/routes/layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router";
+import Header from "~/components/header";
 import { useAuth } from "~/hooks/use-auth";
 
 // TODO ログインしていなくてリダイレクトされたときにUIエラーを出す。
@@ -28,7 +29,12 @@ export default function ProtectedLayout() {
 	}
 
 	if (user) {
-		return <Outlet />;
+		return (
+			<>
+				<Header />
+				<Outlet />
+			</>
+		);
 	}
 
 	return null;

--- a/packages/client/app/routes/layout.tsx
+++ b/packages/client/app/routes/layout.tsx
@@ -16,15 +16,23 @@ export default function ProtectedLayout() {
 	}, [isLoading, user, navigate]);
 
 	if (isLoading) {
-		return <div>Loading...</div>;
+		return (
+			<>
+				<Header />
+				<div style={{ padding: "20px" }}>Loading...</div>
+			</>
+		);
 	}
 
 	if (error) {
 		return (
-			<div style={{ padding: "20px", color: "red" }}>
-				<h2>エラーが発生しました</h2>
-				<p>{error.message}</p>
-			</div>
+			<>
+				<Header />
+				<div style={{ padding: "20px", color: "red" }}>
+					<h2>エラーが発生しました</h2>
+					<p>{error.message}</p>
+				</div>
+			</>
 		);
 	}
 

--- a/packages/client/app/routes/login.tsx
+++ b/packages/client/app/routes/login.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router";
 import { css } from "styled-system/css";
 import { useLogin } from "~/hooks/use-login";
 
@@ -173,6 +174,45 @@ export default function LoginPage() {
 						{isLoading ? "ログイン中..." : "ログイン"}
 					</button>
 				</form>
+
+				<div
+					className={css({
+						mt: "6",
+						textAlign: "center",
+						fontSize: "sm",
+						color: "gray.600",
+					})}
+				>
+					<p>
+						アカウントをお持ちでない方は
+						<Link
+							to="/register"
+							className={css({
+								color: "blue.600",
+								fontWeight: "medium",
+								ml: "1",
+								_hover: {
+									textDecoration: "underline",
+								},
+							})}
+						>
+							新規登録
+						</Link>
+					</p>
+					<Link
+						to="/"
+						className={css({
+							display: "inline-block",
+							mt: "3",
+							color: "gray.500",
+							_hover: {
+								color: "gray.700",
+							},
+						})}
+					>
+						ホームに戻る
+					</Link>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/client/app/routes/login.tsx
+++ b/packages/client/app/routes/login.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Link } from "react-router";
 import { css } from "styled-system/css";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import { useLogin } from "~/hooks/use-login";
 
 export default function LoginPage() {
@@ -20,15 +22,15 @@ export default function LoginPage() {
 				justifyContent: "center",
 				alignItems: "center",
 				minHeight: "100vh",
-				bg: "gray.100",
+				backgroundColor: "#fafafa",
 			})}
 		>
 			<div
 				className={css({
-					p: "8",
-					bg: "white",
-					rounded: "md",
-					shadow: "lg",
+					padding: "32px",
+					backgroundColor: "#fff",
+					borderRadius: "8px",
+					boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08)",
 					width: "100%",
 					maxWidth: "400px",
 				})}
@@ -36,10 +38,10 @@ export default function LoginPage() {
 				<h1
 					className={css({
 						textAlign: "center",
-						mb: "6",
-						fontSize: "2xl",
+						marginBottom: "24px",
+						fontSize: "24px",
 						fontWeight: "bold",
-						color: "gray.800",
+						color: "#1a1a1a",
 					})}
 				>
 					ログイン
@@ -50,137 +52,54 @@ export default function LoginPage() {
 					className={css({
 						display: "flex",
 						flexDirection: "column",
-						gap: "5",
+						gap: "20px",
 					})}
 				>
-					<div
-						className={css({
-							display: "flex",
-							flexDirection: "column",
-							gap: "2",
-						})}
-					>
-						<label
-							htmlFor="email"
-							className={css({
-								fontSize: "sm",
-								fontWeight: "medium",
-								color: "gray.700",
-							})}
-						>
-							メールアドレス
-						</label>
-						<input
-							id="email"
-							type="email"
-							value={email}
-							onChange={(e) => setEmail(e.target.value)}
-							required
-							placeholder="user@example.com"
-							className={css({
-								px: "4",
-								py: "2",
-								rounded: "md",
-								borderWidth: "1px",
-								borderColor: "gray.300",
-								fontSize: "md",
-								outline: "none",
-								transition: "all 0.2s",
-								_focus: {
-									borderColor: "blue.500",
-									ring: "2px",
-									ringColor: "blue.200",
-								},
-							})}
-						/>
-					</div>
+					<Input
+						label="メールアドレス"
+						type="email"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
+						required
+						placeholder="user@example.com"
+					/>
 
-					<div
-						className={css({
-							display: "flex",
-							flexDirection: "column",
-							gap: "2",
-						})}
-					>
-						<label
-							htmlFor="password"
-							className={css({
-								fontSize: "sm",
-								fontWeight: "medium",
-								color: "gray.700",
-							})}
-						>
-							パスワード
-						</label>
-						<input
-							id="password"
-							type="password"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							required
-							placeholder="8文字以上"
-							className={css({
-								px: "4",
-								py: "2",
-								rounded: "md",
-								borderWidth: "1px",
-								borderColor: "gray.300",
-								fontSize: "md",
-								outline: "none",
-								transition: "all 0.2s",
-								_focus: {
-									borderColor: "blue.500",
-									ring: "2px",
-									ringColor: "blue.200",
-								},
-							})}
-						/>
-					</div>
+					<Input
+						label="パスワード"
+						type="password"
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
+						required
+						placeholder="8文字以上"
+					/>
 
 					{error && (
 						<p
 							className={css({
-								color: "red.500",
-								fontSize: "sm",
+								color: "#dc2626",
+								fontSize: "14px",
 								textAlign: "center",
-								fontWeight: "medium",
 							})}
 						>
 							{error}
 						</p>
 					)}
 
-					<button
+					<Button
 						type="submit"
 						disabled={isLoading}
-						className={css({
-							mt: "2",
-							py: "3",
-							bg: "blue.600",
-							color: "white",
-							fontWeight: "bold",
-							rounded: "md",
-							cursor: "pointer",
-							transition: "background-color 0.2s",
-							_hover: {
-								bg: "blue.700",
-							},
-							_disabled: {
-								opacity: 0.7,
-								cursor: "not-allowed",
-							},
-						})}
+						className={css({ width: "100%", marginTop: "8px" })}
 					>
 						{isLoading ? "ログイン中..." : "ログイン"}
-					</button>
+					</Button>
 				</form>
 
 				<div
 					className={css({
-						mt: "6",
+						marginTop: "24px",
 						textAlign: "center",
-						fontSize: "sm",
-						color: "gray.600",
+						fontSize: "14px",
+						color: "#6b6b6b",
 					})}
 				>
 					<p>
@@ -188,9 +107,9 @@ export default function LoginPage() {
 						<Link
 							to="/register"
 							className={css({
-								color: "blue.600",
+								color: "#1a1a1a",
 								fontWeight: "medium",
-								ml: "1",
+								marginLeft: "4px",
 								_hover: {
 									textDecoration: "underline",
 								},
@@ -203,10 +122,10 @@ export default function LoginPage() {
 						to="/"
 						className={css({
 							display: "inline-block",
-							mt: "3",
-							color: "gray.500",
+							marginTop: "12px",
+							color: "#a3a3a3",
 							_hover: {
-								color: "gray.700",
+								color: "#4a4a4a",
 							},
 						})}
 					>

--- a/packages/client/app/routes/post-question.tsx
+++ b/packages/client/app/routes/post-question.tsx
@@ -1,6 +1,9 @@
 import { useRef, useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import { css } from "styled-system/css";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Textarea } from "~/components/ui/textarea";
 import { postQuestion } from "../hooks/use-question";
 
 export default function QuestionsPage() {
@@ -42,11 +45,17 @@ export default function QuestionsPage() {
 			className={css({
 				maxWidth: "600px",
 				margin: "0 auto",
-				padding: "20px",
-				fontSize: "16px",
+				padding: "24px",
 			})}
 		>
-			<h1 className={css({ fontSize: "24px", marginBottom: "16px" })}>
+			<h1
+				className={css({
+					fontSize: "24px",
+					fontWeight: "bold",
+					marginBottom: "24px",
+					color: "#1a1a1a",
+				})}
+			>
 				質問投稿
 			</h1>
 
@@ -56,52 +65,25 @@ export default function QuestionsPage() {
 				className={css({
 					display: "flex",
 					flexDirection: "column",
-					gap: "16px",
+					gap: "20px",
 				})}
 			>
-				<label
-					className={css({
-						display: "flex",
-						flexDirection: "column",
-						gap: "4px",
-					})}
-				>
-					タイトル:
-					<input
-						type="text"
-						name="title"
-						required
-						maxLength={100}
-						className={css({
-							border: "1px solid #000",
-							padding: "8px",
-							borderRadius: "4px",
-						})}
-					/>
-				</label>
+				<Input
+					label="タイトル"
+					type="text"
+					name="title"
+					required
+					maxLength={100}
+					placeholder="質問のタイトルを入力"
+				/>
 
-				<label
-					htmlFor="content"
-					className={css({
-						display: "flex",
-						flexDirection: "column",
-						gap: "4px",
-					})}
-				>
-					内容:
-					<textarea
-						id="content"
-						name="content"
-						required
-						maxLength={5000}
-						className={css({
-							border: "1px solid #000",
-							padding: "8px",
-							borderRadius: "4px",
-							minHeight: "120px",
-						})}
-					/>
-				</label>
+				<Textarea
+					label="内容"
+					name="content"
+					required
+					maxLength={5000}
+					placeholder="質問の内容を詳しく記入してください"
+				/>
 
 				<div
 					className={css({
@@ -109,37 +91,13 @@ export default function QuestionsPage() {
 						gap: "12px",
 					})}
 				>
-					<button
-						type="submit"
-						disabled={isSubmitting}
-						className={css({
-							padding: "10px 16px",
-							background: isSubmitting ? "#999" : "#333",
-							color: "white",
-							borderRadius: "4px",
-							cursor: isSubmitting ? "not-allowed" : "pointer",
-							_hover: { background: isSubmitting ? "#999" : "#555" },
-						})}
-					>
+					<Button type="submit" disabled={isSubmitting}>
 						{isSubmitting ? "投稿中..." : "質問を投稿"}
-					</button>
+					</Button>
 
-					<Link
-						to="/timeline"
-						className={css({
-							padding: "10px 16px",
-							color: "#666",
-							backgroundColor: "#fff",
-							border: "1px solid #d4d4d4",
-							borderRadius: "4px",
-							textDecoration: "none",
-							_hover: {
-								backgroundColor: "#f5f5f5",
-							},
-						})}
-					>
+					<Button as="link" to="/timeline" variant="secondary">
 						キャンセル
-					</Link>
+					</Button>
 				</div>
 			</form>
 		</div>

--- a/packages/client/app/routes/post-question.tsx
+++ b/packages/client/app/routes/post-question.tsx
@@ -1,10 +1,12 @@
 import { useRef, useState } from "react";
+import { Link, useNavigate } from "react-router";
 import { css } from "styled-system/css";
 import { postQuestion } from "../hooks/use-question";
 
 export default function QuestionsPage() {
 	const formRef = useRef<HTMLFormElement>(null);
 	const { post } = postQuestion();
+	const navigate = useNavigate();
 
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -27,6 +29,7 @@ export default function QuestionsPage() {
 			console.log("Question created!", newQuestion);
 
 			formRef.current?.reset();
+			navigate("/timeline");
 		} catch (err) {
 			console.error("質問投稿に失敗しました", err);
 		} finally {
@@ -100,20 +103,44 @@ export default function QuestionsPage() {
 					/>
 				</label>
 
-				<button
-					type="submit"
-					disabled={isSubmitting}
+				<div
 					className={css({
-						padding: "10px 16px",
-						background: isSubmitting ? "#999" : "#333",
-						color: "white",
-						borderRadius: "4px",
-						cursor: isSubmitting ? "not-allowed" : "pointer",
-						_hover: { background: isSubmitting ? "#999" : "#555" },
+						display: "flex",
+						gap: "12px",
 					})}
 				>
-					{isSubmitting ? "投稿中..." : "質問を投稿"}
-				</button>
+					<button
+						type="submit"
+						disabled={isSubmitting}
+						className={css({
+							padding: "10px 16px",
+							background: isSubmitting ? "#999" : "#333",
+							color: "white",
+							borderRadius: "4px",
+							cursor: isSubmitting ? "not-allowed" : "pointer",
+							_hover: { background: isSubmitting ? "#999" : "#555" },
+						})}
+					>
+						{isSubmitting ? "投稿中..." : "質問を投稿"}
+					</button>
+
+					<Link
+						to="/timeline"
+						className={css({
+							padding: "10px 16px",
+							color: "#666",
+							backgroundColor: "#fff",
+							border: "1px solid #d4d4d4",
+							borderRadius: "4px",
+							textDecoration: "none",
+							_hover: {
+								backgroundColor: "#f5f5f5",
+							},
+						})}
+					>
+						キャンセル
+					</Link>
+				</div>
 			</form>
 		</div>
 	);

--- a/packages/client/app/routes/question/index.tsx
+++ b/packages/client/app/routes/question/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { css } from "styled-system/css";
 import ErrorMessage from "~/components/error-message";
 import { useAnswers } from "~/hooks/use-answer";
@@ -39,6 +39,22 @@ export default function QuestionDetailPage() {
 				padding: "16px",
 			})}
 		>
+			<Link
+				to="/timeline"
+				className={css({
+					display: "inline-block",
+					marginBottom: "16px",
+					color: "#666",
+					fontSize: "14px",
+					textDecoration: "none",
+					_hover: {
+						color: "#333",
+					},
+				})}
+			>
+				&larr; 一覧に戻る
+			</Link>
+
 			{question && (
 				<div
 					className={css({

--- a/packages/client/app/routes/question/index.tsx
+++ b/packages/client/app/routes/question/index.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router";
 import { css } from "styled-system/css";
 import ErrorMessage from "~/components/error-message";
 import { Button } from "~/components/ui/button";
+import { Loading } from "~/components/ui/loading";
 import { Textarea } from "~/components/ui/textarea";
 import { useAnswers } from "~/hooks/use-answer";
 import { useQuestions } from "~/hooks/use-question";
@@ -30,7 +31,7 @@ export default function QuestionDetailPage() {
 		return <ErrorMessage message="Question ID is missing" />;
 	}
 
-	if (questionLoading) return <div>Loading question...</div>;
+	if (questionLoading) return <Loading message="質問を読み込み中..." />;
 	if (questionError) return <ErrorMessage message={questionError.message} />;
 
 	return (

--- a/packages/client/app/routes/question/index.tsx
+++ b/packages/client/app/routes/question/index.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Link, useParams } from "react-router";
 import { css } from "styled-system/css";
 import ErrorMessage from "~/components/error-message";
+import { Button } from "~/components/ui/button";
+import { Textarea } from "~/components/ui/textarea";
 import { useAnswers } from "~/hooks/use-answer";
 import { useQuestions } from "~/hooks/use-question";
 
@@ -36,7 +38,7 @@ export default function QuestionDetailPage() {
 			className={css({
 				maxWidth: "800px",
 				margin: "0 auto",
-				padding: "16px",
+				padding: "24px",
 			})}
 		>
 			<Link
@@ -44,11 +46,11 @@ export default function QuestionDetailPage() {
 				className={css({
 					display: "inline-block",
 					marginBottom: "16px",
-					color: "#666",
+					color: "#6b6b6b",
 					fontSize: "14px",
 					textDecoration: "none",
 					_hover: {
-						color: "#333",
+						color: "#1a1a1a",
 					},
 				})}
 			>
@@ -58,17 +60,19 @@ export default function QuestionDetailPage() {
 			{question && (
 				<div
 					className={css({
-						padding: "16px",
+						padding: "20px",
 						borderRadius: "8px",
-						border: "1px solid #ddd",
-						marginBottom: "20px",
+						border: "1px solid #e5e5e5",
+						marginBottom: "24px",
+						backgroundColor: "#fff",
 					})}
 				>
 					<h1
 						className={css({
 							fontSize: "24px",
 							fontWeight: "bold",
-							marginBottom: "8px",
+							marginBottom: "12px",
+							color: "#1a1a1a",
 						})}
 					>
 						{question.title}
@@ -78,6 +82,7 @@ export default function QuestionDetailPage() {
 						className={css({
 							fontSize: "16px",
 							lineHeight: "1.6",
+							color: "#4a4a4a",
 						})}
 					>
 						{question.content}
@@ -87,11 +92,13 @@ export default function QuestionDetailPage() {
 
 			<h2
 				className={css({
-					fontSize: "20px",
-					marginBottom: "8px",
+					fontSize: "18px",
+					fontWeight: "bold",
+					marginBottom: "12px",
+					color: "#1a1a1a",
 				})}
 			>
-				Answers
+				回答一覧
 			</h2>
 
 			{answersError && <ErrorMessage message={answersError.message} />}
@@ -101,29 +108,32 @@ export default function QuestionDetailPage() {
 					display: "flex",
 					flexDirection: "column",
 					gap: "12px",
-					marginBottom: "24px",
+					marginBottom: "32px",
 				})}
 			>
 				{answersLoading ? (
-					<p>Loading answers...</p>
+					<p className={css({ color: "#6b6b6b" })}>読み込み中...</p>
 				) : answers.length === 0 ? (
-					<p>No answers yet.</p>
+					<p className={css({ color: "#6b6b6b" })}>まだ回答はありません</p>
 				) : (
 					answers.map((ans) => (
 						<div
 							key={ans.id}
 							className={css({
-								padding: "12px",
-								border: "1px solid #ddd",
+								padding: "16px",
+								border: "1px solid #e5e5e5",
 								borderRadius: "6px",
+								backgroundColor: "#fff",
 							})}
 						>
-							<p>{ans.content}</p>
+							<p className={css({ color: "#1a1a1a", lineHeight: "1.6" })}>
+								{ans.content}
+							</p>
 							<p
 								className={css({
 									fontSize: "12px",
-									color: "gray",
-									marginTop: "4px",
+									color: "#a3a3a3",
+									marginTop: "8px",
 								})}
 							>
 								{new Date(ans.answeredAt).toLocaleString()}
@@ -148,46 +158,16 @@ export default function QuestionDetailPage() {
 					gap: "12px",
 				})}
 			>
-				<label
-					htmlFor="answer"
-					className={css({
-						fontWeight: "bold",
-						fontSize: "14px",
-					})}
-				>
-					あなたの回答
-				</label>
-
-				<textarea
-					id="answer"
-					className={css({
-						padding: "12px",
-						border: "1px solid #ccc",
-						borderRadius: "6px",
-						height: "120px",
-						resize: "vertical",
-					})}
+				<Textarea
+					label="あなたの回答"
 					value={answerContent}
 					onChange={(e) => setAnswerContent(e.target.value)}
-					placeholder="Write your answer..."
+					placeholder="回答を入力してください..."
 				/>
 
-				<button
-					type="submit"
-					disabled={submitting}
-					aria-disabled={submitting}
-					className={css({
-						padding: "12px",
-						backgroundColor: submitting ? "gray.400" : "blue.500",
-						color: "white",
-						borderRadius: "6px",
-						cursor: submitting ? "not-allowed" : "pointer",
-						fontSize: "16px",
-						fontWeight: "bold",
-					})}
-				>
-					{submitting ? "Posting..." : "Post Answer"}
-				</button>
+				<Button type="submit" disabled={submitting}>
+					{submitting ? "投稿中..." : "回答を投稿"}
+				</Button>
 			</form>
 		</div>
 	);

--- a/packages/client/app/routes/register.tsx
+++ b/packages/client/app/routes/register.tsx
@@ -1,5 +1,7 @@
 import { Link, useNavigate } from "react-router";
 import { css } from "styled-system/css";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import { useLogin } from "~/hooks/use-login";
 import type { CreateUserParams } from "~/types/user";
 import { serverFetch } from "~/utils/fetch";
@@ -40,135 +42,123 @@ export default function RegisterPage() {
 	};
 
 	return (
-		<div className={css({})}>
+		<div
+			className={css({
+				display: "flex",
+				justifyContent: "center",
+				alignItems: "center",
+				minHeight: "100vh",
+				backgroundColor: "#fafafa",
+			})}
+		>
 			<div
 				className={css({
-					margin: "100px auto",
-					maxWidth: "700px",
-					display: "flex",
-					flexDirection: "column",
-					justifyContent: "center",
-					alignItems: "center",
-					gap: "40px",
+					padding: "32px",
+					backgroundColor: "#fff",
+					borderRadius: "8px",
+					boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08)",
+					width: "100%",
+					maxWidth: "400px",
 				})}
 			>
+				<h1
+					className={css({
+						textAlign: "center",
+						marginBottom: "24px",
+						fontSize: "24px",
+						fontWeight: "bold",
+						color: "#1a1a1a",
+					})}
+				>
+					新規登録
+				</h1>
+
 				<form
-					onSubmit={(e) => handleSubmit(e)}
+					onSubmit={handleSubmit}
 					className={css({
 						display: "flex",
 						flexDirection: "column",
-						gap: "8px",
-						width: "400px",
+						gap: "16px",
 					})}
 				>
-					<h2
-						className={css({
-							fontSize: "30px",
-							fontWeight: "bold",
-							textAlign: "center",
-						})}
-					>
-						新規作成
-					</h2>
-					<div>ユーザーID</div>
-					<input
+					<Input
+						label="ユーザーID"
 						type="text"
 						name="displayId"
 						required
-						className={css({
-							padding: "8px",
-							borderRadius: "4px",
-							border: "1px solid #ccc",
-						})}
+						placeholder="your_id"
 					/>
-					<div>氏名</div>
-					<input
+
+					<Input
+						label="氏名"
 						type="text"
 						name="name"
 						required
-						className={css({
-							padding: "8px",
-							borderRadius: "4px",
-							border: "1px solid #ccc",
-						})}
+						placeholder="山田 太郎"
 					/>
-					<div>メールアドレス</div>
-					<input
+
+					<Input
+						label="メールアドレス"
 						type="email"
 						name="email"
-						placeholder="example@example.com"
 						required
-						className={css({
-							padding: "8px",
-							borderRadius: "4px",
-							border: "1px solid #ccc",
-						})}
+						placeholder="example@example.com"
 					/>
-					<div>パスワード</div>
-					<input
+
+					<Input
+						label="パスワード"
 						type="password"
 						name="password"
 						required
-						className={css({
-							padding: "8px",
-							borderRadius: "4px",
-							border: "1px solid #ccc",
-						})}
+						placeholder="8文字以上"
 					/>
-					<button
-						type="submit"
-						className={css({
-							width: "400px",
-							padding: "10px",
-							borderRadius: "4px",
-							border: "none",
-							backgroundColor: "green.500",
-							color: "white",
-							cursor: "pointer",
-						})}
-					>
-						作成
-					</button>
 
-					<div
-						className={css({
-							mt: "6",
-							textAlign: "center",
-							fontSize: "14px",
-							color: "#6b6b6b",
-						})}
+					<Button
+						type="submit"
+						className={css({ width: "100%", marginTop: "8px" })}
 					>
-						<p>
-							既にアカウントをお持ちの方は
-							<Link
-								to="/login"
-								className={css({
-									color: "#2563eb",
-									fontWeight: "medium",
-									ml: "1",
-									_hover: {
-										textDecoration: "underline",
-									},
-								})}
-							>
-								ログイン
-							</Link>
-						</p>
+						登録
+					</Button>
+				</form>
+
+				<div
+					className={css({
+						marginTop: "24px",
+						textAlign: "center",
+						fontSize: "14px",
+						color: "#6b6b6b",
+					})}
+				>
+					<p>
+						既にアカウントをお持ちの方は
 						<Link
-							to="/"
+							to="/login"
 							className={css({
-								display: "inline-block",
-								mt: "3",
-								color: "#9ca3af",
+								color: "#1a1a1a",
+								fontWeight: "medium",
+								marginLeft: "4px",
 								_hover: {
-									color: "#4b5563",
+									textDecoration: "underline",
 								},
 							})}
 						>
-							ホームに戻る
+							ログイン
 						</Link>
-					</div>
-				</form>
+					</p>
+					<Link
+						to="/"
+						className={css({
+							display: "inline-block",
+							marginTop: "12px",
+							color: "#a3a3a3",
+							_hover: {
+								color: "#4a4a4a",
+							},
+						})}
+					>
+						ホームに戻る
+					</Link>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/client/app/routes/register.tsx
+++ b/packages/client/app/routes/register.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { css } from "styled-system/css";
 import { useLogin } from "~/hooks/use-login";
 import type { CreateUserParams } from "~/types/user";
@@ -129,6 +129,45 @@ export default function RegisterPage() {
 					>
 						作成
 					</button>
+
+					<div
+						className={css({
+							mt: "6",
+							textAlign: "center",
+							fontSize: "14px",
+							color: "#6b6b6b",
+						})}
+					>
+						<p>
+							既にアカウントをお持ちの方は
+							<Link
+								to="/login"
+								className={css({
+									color: "#2563eb",
+									fontWeight: "medium",
+									ml: "1",
+									_hover: {
+										textDecoration: "underline",
+									},
+								})}
+							>
+								ログイン
+							</Link>
+						</p>
+						<Link
+							to="/"
+							className={css({
+								display: "inline-block",
+								mt: "3",
+								color: "#9ca3af",
+								_hover: {
+									color: "#4b5563",
+								},
+							})}
+						>
+							ホームに戻る
+						</Link>
+					</div>
 				</form>
 			</div>
 		</div>

--- a/packages/client/app/routes/timeline.tsx
+++ b/packages/client/app/routes/timeline.tsx
@@ -1,13 +1,15 @@
 import { Link } from "react-router-dom";
 import { css } from "styled-system/css";
+import ErrorMessage from "~/components/error-message";
+import { Loading } from "~/components/ui/loading";
 import { useQuestions } from "../hooks/use-question";
 
 export default function TimelinePage() {
 	const { questions, isLoading, error } = useQuestions();
 
-	if (isLoading) return <p>Loading...</p>;
-	if (error) return <p>Error: {error.message}</p>;
-	if (!questions) return <p>No questions found</p>;
+	if (isLoading) return <Loading message="質問一覧を読み込み中..." />;
+	if (error) return <ErrorMessage message={error.message} />;
+	if (!questions) return <Loading message="質問が見つかりません" />;
 
 	return (
 		<div>

--- a/packages/client/app/routes/users/profile.tsx
+++ b/packages/client/app/routes/users/profile.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { css } from "styled-system/css";
 import ErrorMessage from "~/components/error-message";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import { useProfile } from "~/hooks/use-profile";
 
 export default function ProfilePage() {
@@ -12,7 +14,11 @@ export default function ProfilePage() {
 	}, [user]);
 
 	if (isLoading)
-		return <div className={css({ padding: "16px" })}>Loading profile...</div>;
+		return (
+			<div className={css({ padding: "24px", color: "#6b6b6b" })}>
+				Loading profile...
+			</div>
+		);
 
 	if (error) return <ErrorMessage message={error.message} />;
 
@@ -23,9 +29,9 @@ export default function ProfilePage() {
 	return (
 		<div
 			className={css({
-				maxWidth: "800px",
+				maxWidth: "600px",
 				margin: "0 auto",
-				padding: "16px",
+				padding: "24px",
 			})}
 		>
 			{user && (
@@ -33,7 +39,7 @@ export default function ProfilePage() {
 					className={css({
 						padding: "24px",
 						borderRadius: "8px",
-						border: "1px solid #e2e8f0",
+						border: "1px solid #e5e5e5",
 						marginBottom: "32px",
 						backgroundColor: "#fff",
 					})}
@@ -42,102 +48,91 @@ export default function ProfilePage() {
 						className={css({
 							fontSize: "24px",
 							fontWeight: "bold",
-							marginBottom: "16px",
+							marginBottom: "20px",
+							color: "#1a1a1a",
 						})}
 					>
-						My Profile
+						マイプロフィール
 					</h1>
 
 					<div className={css({ marginBottom: "12px" })}>
 						<p
 							className={css({
-								fontSize: "16px",
-								lineHeight: "1.6",
-								marginBottom: "8px",
+								fontSize: "14px",
+								color: "#6b6b6b",
+								marginBottom: "4px",
 							})}
 						>
-							<strong>ID:</strong> {user.id}
+							ID
 						</p>
+						<p
+							className={css({
+								fontSize: "16px",
+								color: "#1a1a1a",
+							})}
+						>
+							{user.id}
+						</p>
+					</div>
 
-						<p className={css({ fontSize: "16px", lineHeight: "1.6" })}>
-							<strong>Display ID:</strong> {user.displayId}
+					<div>
+						<p
+							className={css({
+								fontSize: "14px",
+								color: "#6b6b6b",
+								marginBottom: "4px",
+							})}
+						>
+							ユーザーID
+						</p>
+						<p
+							className={css({
+								fontSize: "16px",
+								color: "#1a1a1a",
+							})}
+						>
+							{user.displayId}
 						</p>
 					</div>
 				</div>
 			)}
 
-			{/* 編集フォーム */}
-			<h2
-				className={css({
-					fontSize: "20px",
-					fontWeight: "bold",
-					marginBottom: "16px",
-					borderBottom: "1px solid #e2e8f0",
-					paddingBottom: "8px",
-				})}
-			>
-				Edit Profile
-			</h2>
-
 			<div
 				className={css({
 					padding: "24px",
-					border: "1px solid #e2e8f0",
+					border: "1px solid #e5e5e5",
 					borderRadius: "8px",
 					backgroundColor: "#fff",
 				})}
 			>
-				<h3
+				<h2
 					className={css({
 						fontSize: "18px",
 						fontWeight: "bold",
-						marginBottom: "12px",
+						marginBottom: "20px",
+						color: "#1a1a1a",
 					})}
 				>
-					Display Name
-				</h3>
+					プロフィール編集
+				</h2>
 
-				<input
-					type="text"
-					value={nameContent}
-					onChange={(e) => setNameContent(e.target.value)}
-					placeholder="Enter your name"
-					disabled={isSubmitting}
-					className={css({
-						width: "100%",
-						padding: "12px",
-						border: "1px solid #cbd5e1",
-						borderRadius: "6px",
-						marginBottom: "12px",
-						outline: "none",
-						fontSize: "16px",
-						_focus: {
-							borderColor: "#3b82f6",
-							boxShadow: "0 0 0 1px #3b82f6",
-						},
-					})}
-				/>
+				<div className={css({ marginBottom: "16px" })}>
+					<Input
+						label="表示名"
+						type="text"
+						value={nameContent}
+						onChange={(e) => setNameContent(e.target.value)}
+						placeholder="表示名を入力"
+						disabled={isSubmitting}
+					/>
+				</div>
 
-				<button
-					type="button"
+				<Button
 					onClick={handleUpdate}
 					disabled={isSubmitting || !nameContent.trim()}
-					className={css({
-						padding: "10px 20px",
-						backgroundColor: isSubmitting ? "#94a3b8" : "#2563eb",
-						color: "white",
-						fontWeight: "bold",
-						borderRadius: "6px",
-						cursor: isSubmitting ? "not-allowed" : "pointer",
-						transition: "background-color 0.2s",
-						border: "none",
-						_hover: {
-							backgroundColor: isSubmitting ? "#94a3b8" : "#1d4ed8",
-						},
-					})}
 				>
-					{isSubmitting ? "Updating..." : "Update Profile"}
-				</button>
+					{isSubmitting ? "更新中..." : "更新する"}
+				</Button>
 			</div>
 		</div>
 	);

--- a/packages/client/app/routes/users/profile.tsx
+++ b/packages/client/app/routes/users/profile.tsx
@@ -3,6 +3,7 @@ import { css } from "styled-system/css";
 import ErrorMessage from "~/components/error-message";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { Loading } from "~/components/ui/loading";
 import { useProfile } from "~/hooks/use-profile";
 
 export default function ProfilePage() {
@@ -13,12 +14,7 @@ export default function ProfilePage() {
 		if (user) setNameContent(user.name);
 	}, [user]);
 
-	if (isLoading)
-		return (
-			<div className={css({ padding: "24px", color: "#6b6b6b" })}>
-				Loading profile...
-			</div>
-		);
+	if (isLoading) return <Loading message="プロフィールを読み込み中..." />;
 
 	if (error) return <ErrorMessage message={error.message} />;
 


### PR DESCRIPTION
これはちょっと差分多いから一年生とかにはレビュー担当してもらわないつもり。もうちょいすくないやつを後でPRだす

以下はやったこと
- ボタンとかTextareaをコンポーネントに分けた
- ヘッダーを追加した
- 各ページにページ遷移するためのボタンを追加

UIはこんな感じ
<img width="1919" height="997" alt="image" src="https://github.com/user-attachments/assets/44bf82fe-c263-4286-8d8b-e372c39563fe" />
